### PR TITLE
push-notify: contents changes

### DIFF
--- a/pkg/escape/app/push-notify.hoon
+++ b/pkg/escape/app/push-notify.hoon
@@ -180,17 +180,17 @@
       `state
     ::
     =/  include-details=?
-      ?.  .^(? %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/has-bucket/landscape/(scot %tas pushNotifications)/noun)
+      ?.  .^(? %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/has-bucket/landscape/(scot %tas 'pushNotifications')/noun)
         %.n
-      ?.  .^(? %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/has-entry/landscape/(scot %tas pushNotifications)/(scot %tas pushNotificationDetails)/noun)
+      ?.  .^(? %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/has-entry/landscape/(scot %tas 'pushNotifications')/(scot %tas 'pushNotificationDetails')/noun)
         %.n
       =/  include-data=data:settings
-        .^(data:settings %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/entry/landscape/(scot %tas pushNotifications)/(scot %tas pushNotificationDetails)/noun)
-      ?.  ?=(%entry -.include.data)
+        .^(data:settings %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/entry/landscape/(scot %tas 'pushNotifications')/(scot %tas 'pushNotificationDetails')/noun)
+      ?.  ?=(%entry -.include-data)
         %.n
-      ?.  ?=(%b -.val.include.data)
+      ?.  ?=(%b -.val.include-data)
         %.n
-      p.val.include.data
+      p.val.include-data
     ::  send http request
     ::
     =/  =header-list:http
@@ -198,7 +198,7 @@
       ==
     =/  note=notification  +.upd
     =/  title=@t  (contents-to-cord title.body.note)
-    =/  json-list
+    =/  json-list=(list [@t json])
       :~  to+s+p.val.data
           title+s+title
           :-  %data
@@ -209,7 +209,7 @@
     =.  json-list
       ?:  include-details
         =/  body=@t  (contents-to-cord content.body.note)
-        (weld json-list ~[body+s+body])
+        [body+s+body json-list]
       json-list
     =|  =request:http
     =:  method.request       %'POST'
@@ -226,7 +226,7 @@
   ==
 ::
 ++  contents-to-cord
-  |=  contents=(list contents)
+  |=  contents=(list content:hark-store)
   %+  rap  3
   %+  turn  contents
   |=  [type=?(%ship %text) content=@]

--- a/pkg/escape/app/push-notify.hoon
+++ b/pkg/escape/app/push-notify.hoon
@@ -184,14 +184,7 @@
       :~  ['Content-Type' 'application/json']
       ==
     =/  note=notification  +.upd
-    =/  json-title=@t
-      %+  rap  3
-      %+  turn  title.body.note
-      |=  content=[?(%ship %text) @]
-      ^-  @t
-      ?:  ?=(%text -.content)
-        +.content
-      (scot %p +.content)
+    =/  title=@t  (contents-to-cord title.body.note)
     =|  =request:http
      =:  method.request       %'POST'
          url.request          'https://exp.host/--/api/v2/push/send'
@@ -202,7 +195,7 @@
        %-  en-json:html
        %-  pairs:enjs:format
        :~  to+s+p.val.data
-           title+s+json-title
+           title+s+title
            :-  %data
            %-  pairs:enjs:format
            :~  redirect+s+(get-notification-redirect link.body.note)
@@ -211,6 +204,18 @@
     ==
     [~[[%pass /push-notification/(scot %da now.bowl) %arvo %i %request request *outbound-config:iris]] state]
   ==
+::
+++  contents-to-cord
+  |=  contents=(list contents)
+  %+  rap  3
+  %+  turn  contents
+  |=  [type=?(%ship %text) content=@]
+  ^-  @t
+  ?:  ?=(%ship type)
+    (scot %p content)
+  ?.  =('New messages from ' content)
+    content
+  'New DM from '
 ::
 ++  get-notification-redirect
   |=  link=path

--- a/pkg/escape/app/push-notify.hoon
+++ b/pkg/escape/app/push-notify.hoon
@@ -186,21 +186,21 @@
     =/  note=notification  +.upd
     =/  title=@t  (contents-to-cord title.body.note)
     =|  =request:http
-     =:  method.request       %'POST'
-         url.request          'https://exp.host/--/api/v2/push/send'
-         header-list.request  header-list
-         body.request
-       :-  ~
-       %-  as-octt:mimes:html
-       %-  en-json:html
-       %-  pairs:enjs:format
-       :~  to+s+p.val.data
-           title+s+title
-           :-  %data
-           %-  pairs:enjs:format
-           :~  redirect+s+(get-notification-redirect link.body.note)
-               ship+s+(scot %p our.bowl)
-       ==  ==
+    =:  method.request       %'POST'
+        url.request          'https://exp.host/--/api/v2/push/send'
+        header-list.request  header-list
+        body.request
+      :-  ~
+      %-  as-octt:mimes:html
+      %-  en-json:html
+      %-  pairs:enjs:format
+      :~  to+s+p.val.data
+          title+s+title
+          :-  %data
+          %-  pairs:enjs:format
+          :~  redirect+s+(get-notification-redirect link.body.note)
+              ship+s+(scot %p our.bowl)
+      ==  ==
     ==
     [~[[%pass /push-notification/(scot %da now.bowl) %arvo %i %request request *outbound-config:iris]] state]
   ==

--- a/pkg/escape/app/push-notify.hoon
+++ b/pkg/escape/app/push-notify.hoon
@@ -166,7 +166,7 @@
   ?+    -.upd  `state
   ::
       %add-note
-    ::  get token from settings-store
+    ::  read from settings-store
     ::
     ?.  .^(? %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/has-bucket/landscape/escape-app/noun)
       `state
@@ -178,6 +178,19 @@
       `state
     ?.  ?=(%s -.val.data)
       `state
+    ::
+    =/  include-details=?
+      ?.  .^(? %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/has-bucket/landscape/(scot %tas pushNotifications)/noun)
+        %.n
+      ?.  .^(? %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/has-entry/landscape/(scot %tas pushNotifications)/(scot %tas pushNotificationDetails)/noun)
+        %.n
+      =/  include-data=data:settings
+        .^(data:settings %gx /(scot %p our.bowl)/settings-store/(scot %da now.bowl)/entry/landscape/(scot %tas pushNotifications)/(scot %tas pushNotificationDetails)/noun)
+      ?.  ?=(%entry -.include.data)
+        %.n
+      ?.  ?=(%b -.val.include.data)
+        %.n
+      p.val.include.data
     ::  send http request
     ::
     =/  =header-list:http
@@ -185,6 +198,19 @@
       ==
     =/  note=notification  +.upd
     =/  title=@t  (contents-to-cord title.body.note)
+    =/  json-list
+      :~  to+s+p.val.data
+          title+s+title
+          :-  %data
+          %-  pairs:enjs:format
+          :~  redirect+s+(get-notification-redirect link.body.note)
+              ship+s+(scot %p our.bowl)
+      ==  ==
+    =.  json-list
+      ?:  include-details
+        =/  body=@t  (contents-to-cord content.body.note)
+        (weld json-list ~[body+s+body])
+      json-list
     =|  =request:http
     =:  method.request       %'POST'
         url.request          'https://exp.host/--/api/v2/push/send'
@@ -194,13 +220,7 @@
       %-  as-octt:mimes:html
       %-  en-json:html
       %-  pairs:enjs:format
-      :~  to+s+p.val.data
-          title+s+title
-          :-  %data
-          %-  pairs:enjs:format
-          :~  redirect+s+(get-notification-redirect link.body.note)
-              ship+s+(scot %p our.bowl)
-      ==  ==
+      json-list
     ==
     [~[[%pass /push-notification/(scot %da now.bowl) %arvo %i %request request *outbound-config:iris]] state]
   ==


### PR DESCRIPTION
827ffad will rewrite notifications about direct messages from, e.g.

"New messages from ~zod"

to

"New DM from ~zod"

Forthcoming is a change to include notification body given a user setting.