### PR TITLE
lib/util: return cited ships in monospace

### DIFF
--- a/pkg/interface/src/logic/lib/util.tsx
+++ b/pkg/interface/src/logic/lib/util.tsx
@@ -280,9 +280,9 @@ export function writeText(str: string | null): Promise<void> {
 export const citeNickname = (ship: string, showNickname?: boolean, nickname?: string) => {
   if (showNickname) {
     if (ship.length === 27) {
-      return <>{nickname} {cite(ship)}</>;
+      return <>{nickname} <Text mono gray>{cite(ship)}</Text></>;
     } else {
-      return `${nickname} ${cite(ship)}`;
+      return <>{nickname} <Text mono gray>{cite(ship)}</Text></>;
     }
   }
 


### PR DESCRIPTION
Perhaps it's just to taste? To me, seeing nicknames and patps side by side needs some differentiation, and we use monospace for ships names elsewhere in the UI.