### PR TITLE
landscape/components: add two group popover route transparencies

### DIFF
--- a/pkg/interface/src/views/components/FormGroup.tsx
+++ b/pkg/interface/src/views/components/FormGroup.tsx
@@ -154,7 +154,7 @@ export function FormGroup(props: { onReset?: () => void; } & PropFunc<typeof Box
         bottom="0px"
         p={3}
         gapX={2}
-        backgroundColor="white"
+        backgroundColor="transparent"
         borderTop={1}
         borderTopColor="washedGray"
       >

--- a/pkg/interface/src/views/landscape/components/SidebarItem.tsx
+++ b/pkg/interface/src/views/landscape/components/SidebarItem.tsx
@@ -25,7 +25,7 @@ export const SidebarItem = ({
     <HoverBoxLink
       to={to}
       selected={selected}
-      bg="white"
+      bg="transparent"
       bgActive="washedGray"
       display="flex"
       px={3}


### PR DESCRIPTION
Adds two dropped transparencies so the channels + group settings popover dialogue looks better, matches theme.